### PR TITLE
fixed bug with missing title, if title is in underscore property

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,13 +43,16 @@ var parseAtomFeed = function(xmlObj, callback) {
   if (feed.link[1] && feed.link[1].$.href) {
     json.feed.feedUrl = feed.link[1].$.href;
   }
-  if (feed.title[0]) {
+  if (feed.title[0]._) {
+    json.feed.title = feed.title[0]._;
+  } else if (feed.title[0]) {
     json.feed.title = feed.title[0];
   }
   var entries = feed.entry;
   (entries || []).forEach(function (entry) {
     var item = {};
-    if (entry.title) item.title = entry.title[0];
+    if (entry.title && entry.title[0]._) item.title = entry.title[0]._;
+    else if (entry.title) item.title = entry.title[0];
     if (entry.link) item.link = entry.link[0].$.href;
     if (entry.updated) item.pubDate = new Date(entry.updated[0]).toISOString();
     if (entry.author) item.author = entry.author[0].name[0];


### PR DESCRIPTION
If the title of a feed or its entry is in a "_" property, it was not mapped correctly.