### PR TITLE
Added error handling to response object in parseURL method

### DIFF
--- a/dist/rss-parser.js
+++ b/dist/rss-parser.js
@@ -123,9 +123,7 @@ Parser.parseURL = function(url, callback) {
     res.on('end', function() {
       return Parser.parseString(xml, callback);
     })
-		res.on('error', function(){
-			callback;
-		})
+    res.on('error', callback);
   })
   req.on('error', callback);
 }

--- a/dist/rss-parser.js
+++ b/dist/rss-parser.js
@@ -123,6 +123,9 @@ Parser.parseURL = function(url, callback) {
     res.on('end', function() {
       return Parser.parseString(xml, callback);
     })
+		res.on('error', function(){
+			callback;
+		})
   })
   req.on('error', callback);
 }


### PR DESCRIPTION
Encountered an unhandled error due to a missing '>' in a feed I was trying to pull. This lets the parser continue.