### PR TITLE
Fix for when no "itunes:owner"

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,8 @@ var decorateItunes = function decorateItunes(json, channel) {
       },
       image: channel['itunes:image'][0].$.href
     };
+  } else {
+    json.feed.itunes = {}
   }
   PODCAST_TOP_FIELDS.forEach(function(f) {
     if (channel['itunes:' + f]) json.feed.itunes[f] = channel['itunes:' + f][0];


### PR DESCRIPTION
Hi @bobby-brennan, love this package, thank you for creating it.

I've been getting some Typeerrors from feeds which have itunes fields but no `"itunes:owner"`. I traced it to the `decorateItunes` function:

it looks like `json.feed.itunes` is only created if there is an `itunes:owner`; if there isn't an *owner* but there are *other* itunes fields, the loop tries to add the `PODCAST_TOP_FIELDS` to `json.feed.itunes`, which obviously doesn't exist. So I just added a line to create the property either way.

I doubt my fix is the ideal solution, but it seems to solve the problem for me!