### PR TITLE
Another iTunes attributes fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,18 +142,28 @@ var parseRSS2 = function(xmlObj, callback) {
 var decorateItunes = function decorateItunes(json, channel) {
   var items = channel.item || [],
       entry = {};
+  json.feed.itunes = {}
 
   if (channel['itunes:owner']) {
-    json.feed.itunes = {
-      owner: {
-         name: channel['itunes:owner'][0]['itunes:name'][0],
-         email: channel['itunes:owner'][0]['itunes:email'][0]
-      },
-      image: channel['itunes:image'][0].$.href
-    };
-  } else {
-    json.feed.itunes = {}
+    var owner = {},
+        image;
+
+    if(channel['itunes:owner'][0]['itunes:name']) {
+      owner.name = channel['itunes:owner'][0]['itunes:name'][0];
+    }
+    if(channel['itunes:owner'][0]['itunes:email']) {
+      owner.email = channel['itunes:owner'][0]['itunes:email'][0];
+    }
+    if(channel['itunes:image']) {
+      image = channel['itunes:image'][0].$.href
+    }
+
+    if(image) {
+      json.feed.itunes.image = image;
+    }
+    json.feed.itunes.owner = owner;
   }
+  
   PODCAST_TOP_FIELDS.forEach(function(f) {
     if (channel['itunes:' + f]) json.feed.itunes[f] = channel['itunes:' + f][0];
   });


### PR DESCRIPTION
Hello, me again. It looks like people's use of the iTunes tags is very non-standard which leads to lots of `Cannot read property 0 of undefined` TypeErrors - because sometimes there is a `name` and sometimes there isn't.

This fix is very clumsy I know, but it seems to work for me...