### PR TITLE
Switch to the "request" npm package for getting the rss content

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,15 +190,9 @@ Parser.parseString = function(xml, callback) {
 
 Parser.parseURL = function(feedUrl, callback) {
   var xml = '';
-  var req = request(feedUrl, { headers: {'User-Agent': 'rss-parser'} }, function(err, res, body) {
-    if (res.statusCode >= 300) return callback(new Error("Status code " + res.statusCode));
-    res.setEncoding('utf8');
-    res.on('data', function(chunk) {
-      xml += chunk;
-    });
-    res.on('end', function() {
-      return Parser.parseString(xml, callback);
-    })
+  var req = request({uri: feedUrl, headers: {'User-Agent': 'rss-parser'}}, function(err, res, body) {
+    if (res.statusCode >= 400) return callback(new Error("Status code " + res.statusCode));
+    return Parser.parseString(body, callback);
   });
   req.on('error', callback);
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "entities": "^1.1.1",
+    "request": "^2.75.0",
     "xml2js": "^0.4.15"
   },
   "directories": {


### PR DESCRIPTION
That way, 301 redirect statuses will be handled by the request library instead of throwing an error.