### PR TITLE
Fix for missing image in itunes:image on item

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ var PODCAST_ITEM_FIELDS = [
   'subtitle',
   'summary',
   'explicit',
-  'duration'
+  'duration',
+  'image'
 ];
 
 
@@ -171,7 +172,13 @@ var decorateItunes = function decorateItunes(json, channel) {
     entry = json.feed.entries[index];
     PODCAST_ITEM_FIELDS.forEach(function(f) {
       entry.itunes = entry.itunes || {};
-      if (item['itunes:' + f]) entry.itunes[f] = item['itunes:' + f][0];
+      if (item['itunes:' + f]) {
+        if (f == 'image' && item['itunes:' + f][0].$ && item['itunes:' + f][0].$.href) {
+          entry.itunes[f] = item['itunes:' + f][0].$.href;
+        } else {
+          entry.itunes[f] = item['itunes:' + f][0];
+        }
+      }
     });
     json.feed.entries[index] = entry;
   });

--- a/test/input/narro.rss
+++ b/test/input/narro.rss
@@ -1,1 +1,39 @@
-<?xml version="1.0" encoding="UTF-8"?><rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0"><channel><title>foobar on Narro</title><link>http://on.narro.co/f</link><description>foobar uses Narro to create a podcast of articles transcribed to audio.</description><language>en</language><copyright>All article content copyright of respective source authors.</copyright><managingEditor>foobar@gmail.com</managingEditor><webMaster>josh@narro.co</webMaster><pubDate>Fri, 08 Jul 2016 13:40:00 UTC</pubDate><generator>gopod - http://github.com/jbckmn/gopod</generator><ttl>20</ttl><itunes:author>foobar@gmail.com</itunes:author><itunes:subtitle>foobar uses Narro to create a podcast of articles transcribed to audio.</itunes:subtitle><itunes:summary>foobar uses Narro to create a podcast of articles transcribed to audio.</itunes:summary><itunes:explicit>no</itunes:explicit><itunes:owner><itunes:name>foobar</itunes:name><itunes:email>foobar@gmail.com</itunes:email></itunes:owner><itunes:image href="https://www.narro.co/images/narro-icon-lg.png"></itunes:image><atom:link href="http://on.narro.co/f" rel="self" type="application/rss+xml"></atom:link><item><link>https://www.narro.co/article/54e703933058540300000069</link><description>Listen to your reading list anywhere. Narro will take your bookmarked articles and read them back to you as a podcast.&lt;br/&gt; http://www.narro.co/faq&lt;br/&gt; &lt;ul class=&#34;linkList&#34;&gt;&lt;/ul&gt;</description><title>FAQ for Narro</title><pubDate>Fri, 20 Feb 2015 09:51:15 UTC</pubDate><author>foobar@gmail.com</author><guid>https://www.narro.co/article/54e703933058540300000069</guid><itunes:author>foobar@gmail.com</itunes:author><itunes:subtitle>FAQ for Narro</itunes:subtitle><itunes:summary>Listen to your reading list anywhere. Narro will take your bookmarked articles and read them back to you as a podcast. ... http://www.narro.co/faq ... &lt;ul class=&#34;linkList&#34;&gt;&lt;/ul&gt;</itunes:summary><itunes:explicit>no</itunes:explicit><itunes:duration>74</itunes:duration><enclosure url="https://s3.amazonaws.com/nareta-articles/audio/54d046c293f79c0300000003/7e2d2b00-a945-441a-f49b-063786a319a4.mp3" length="74" type="audio/mpeg"></enclosure></item></channel></rss>
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+  <channel>
+    <title>foobar on Narro</title>
+    <link>http://on.narro.co/f</link>
+    <description>foobar uses Narro to create a podcast of articles transcribed to audio.</description>
+    <language>en</language>
+    <copyright>All article content copyright of respective source authors.</copyright>
+    <managingEditor>foobar@gmail.com</managingEditor>
+    <webMaster>josh@narro.co</webMaster>
+    <pubDate>Fri, 08 Jul 2016 13:40:00 UTC</pubDate>
+    <generator>gopod - http://github.com/jbckmn/gopod</generator>
+    <ttl>20</ttl>
+    <itunes:author>foobar@gmail.com</itunes:author>
+    <itunes:subtitle>foobar uses Narro to create a podcast of articles transcribed to audio.</itunes:subtitle>
+    <itunes:summary>foobar uses Narro to create a podcast of articles transcribed to audio.</itunes:summary>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>foobar</itunes:name>
+      <itunes:email>foobar@gmail.com</itunes:email>
+    </itunes:owner>
+    <itunes:image href="https://www.narro.co/images/narro-icon-lg.png"></itunes:image>
+    <atom:link href="http://on.narro.co/f" rel="self" type="application/rss+xml"></atom:link>
+    <item>
+      <link>https://www.narro.co/article/54e703933058540300000069</link>
+      <description>Listen to your reading list anywhere. Narro will take your bookmarked articles and read them back to you as a podcast.&lt;br/&gt; http://www.narro.co/faq&lt;br/&gt; &lt;ul class=&#34;linkList&#34;&gt;&lt;/ul&gt;</description>
+      <title>FAQ for Narro</title>
+      <pubDate>Fri, 20 Feb 2015 09:51:15 UTC</pubDate>
+      <author>foobar@gmail.com</author>
+      <guid>https://www.narro.co/article/54e703933058540300000069</guid>
+      <itunes:author>foobar@gmail.com</itunes:author>
+      <itunes:subtitle>FAQ for Narro</itunes:subtitle>
+      <itunes:summary>Listen to your reading list anywhere. Narro will take your bookmarked articles and read them back to you as a podcast. ... http://www.narro.co/faq ... &lt;ul class=&#34;linkList&#34;&gt;&lt;/ul&gt;</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:duration>74</itunes:duration>
+      <enclosure url="https://s3.amazonaws.com/nareta-articles/audio/54d046c293f79c0300000003/7e2d2b00-a945-441a-f49b-063786a319a4.mp3" length="74" type="audio/mpeg"></enclosure>
+    </item>
+  </channel>
+</rss>

--- a/test/input/narro.rss
+++ b/test/input/narro.rss
@@ -33,6 +33,7 @@
       <itunes:summary>Listen to your reading list anywhere. Narro will take your bookmarked articles and read them back to you as a podcast. ... http://www.narro.co/faq ... &lt;ul class=&#34;linkList&#34;&gt;&lt;/ul&gt;</itunes:summary>
       <itunes:explicit>no</itunes:explicit>
       <itunes:duration>74</itunes:duration>
+      <itunes:image href="http://example.com/someImage.jpg"/>
       <enclosure url="https://s3.amazonaws.com/nareta-articles/audio/54d046c293f79c0300000003/7e2d2b00-a945-441a-f49b-063786a319a4.mp3" length="74" type="audio/mpeg"></enclosure>
     </item>
   </channel>

--- a/test/output/narro.json
+++ b/test/output/narro.json
@@ -19,7 +19,8 @@
           "subtitle": "FAQ for Narro",
           "summary": "Listen to your reading list anywhere. Narro will take your bookmarked articles and read them back to you as a podcast. ... http://www.narro.co/faq ... <ul class=\"linkList\"></ul>",
           "explicit": "no",
-          "duration": "74"
+          "duration": "74",
+          "image": "http://example.com/someImage.jpg"
         }
       }
     ],


### PR DESCRIPTION
Hi!
Thanks for creating an easy to use parser.
It currently doesn't pick up itunes:image in items, so I added that. I'm a bit under time pressure, so I'm not sure my implementation is the best.

Br
Jay