### PR TITLE
Passes auth info from the URL to the underlying http(s) get() call

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,7 @@ Parser.parseURL = function(feedUrl, settings, callback) {
   var get = feedUrl.indexOf('https') === 0 ? HTTPS.get : HTTP.get;
   var parsedUrl = url.parse(feedUrl);
   var req = get({
+    auth: parsedUrl.auth,
     protocol: parsedUrl.protocol,
     hostname: parsedUrl.hostname,
     path: parsedUrl.path,


### PR DESCRIPTION
url.parse() returns an 'auth' property: https://nodejs.org/docs/latest/api/url.html#url_urlobject_auth
http(s) accepts an auth property: https://nodejs.org/api/http.html#http_http_request_options_callback
This allows you to use URLs like http://username:password@my.web.site.  Previously the auth information would be parsed but not used in the actual call.