### PR TITLE
Handle rare null XML2JS parse error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,6 +240,9 @@ Parser.parseString = function(xml, options, callback) {
   }
   XML2JS.parseString(xml, function(err, result) {
     if (err) return callback(err);
+    if (!result) {
+      return callback(new Error('Unable to parse XML.'));
+    }
     if (result.feed) {
       return parseAtomFeed(result, options, callback)
     } else if (result.rss && result.rss.$.version && result.rss.$.version.indexOf('2') === 0) {


### PR DESCRIPTION
1. Thanks for a useful lib!
2. I've been processing a lot of iTunes feeds with `rss-parser` and on very rare occasions I get an unhandled error due to `XML2JS` returning `null` for `parseString`, which means `result.feed` does not evaluate because `result` is undefined.

Probably best dealt with at `XML2JS` but I've updated my clone of `xml2js` to handle the error as in this MR for the moment. If it's fixed in `xml2js` then I guess it's caught in both places.