### PR TITLE
Adding support for special iTunes tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,9 @@ var PODCAST_ITEM_FIELDS = ([
   'summary',
   'explicit',
   'duration',
-  'image'
+  'image',
+  'episode',
+  'season'
 ]).map(mapItunesField);
 
 


### PR DESCRIPTION
This updates the list of special iTunes fields that we parse to include `iTunes:episode` and `iTunes:season`, which were [added to their RSS spec in June 2017](http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf).

Note: I'm making this PR because it didn't seem like the `options` object supported custom `itunes:` tags and instead they're explicitly defined in the code. Let me know if

* there is a way to get `options` to do this in its current form, in which case I'll happily do a documentation PR instead
* you'd rather provide a way for the `options` object to allow custom mappings (I was thinking something like `var options = { items: [...], itunes: ['episode','season'] }` and extending the base array in `PODCAST_ITEM_FIELDS`)