### PR TITLE
prevent RangeError when entry.updated is empty

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -112,7 +112,7 @@ class Parser {
       if (entry.link && entry.link.length) {
         item.link = utils.getLink(entry.link, 'alternate', 0);
       }
-      if (entry.updated && entry.updated.length) item.pubDate = new Date(entry.updated[0]).toISOString();
+      if (entry.updated && entry.updated.length && entry.updated[0].length) item.pubDate = new Date(entry.updated[0]).toISOString();
       if (entry.author && entry.author.length) item.author = entry.author[0].name[0];
       if (entry.content && entry.content.length) {
         item.content = utils.getContent(entry.content[0]);


### PR DESCRIPTION
Unfournatly the feed i was parsing (https://www.tagesschau.de/xml/atom/) has an empty entry.updated element which killed my app with an 'RangeError: invalid time value' error (https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Fehler/Invalid_date). 
A simple check if its empty can fix the crash.