### PR TITLE
Fixing crash when rss feed has no attributes in <rss> tag.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -35,11 +35,11 @@ class Parser {
         let feed = null;
         if (result.feed) {
           feed = this.buildAtomFeed(result);
-        } else if (result.rss && result.rss.$.version && result.rss.$.version.match(/^2/)) {
+        } else if (result.rss && result.rss.$ && result.rss.$.version && result.rss.$.version.match(/^2/)) {
           feed = this.buildRSS2(result);
         } else if (result['rdf:RDF']) {
           feed = this.buildRSS1(result);
-        } else if (result.rss && result.rss.$.version && result.rss.$.version.match(/0\.9/)) {
+        } else if (result.rss && result.rss.$ && result.rss.$.version && result.rss.$.version.match(/0\.9/)) {
           feed = this.buildRSS0_9(result);
         } else {
           return reject(new Error("Feed not recognized as RSS 1 or 2."))


### PR DESCRIPTION
When the RSS feed has no attribute in the root <rss> tag the lib crashes. E.g.: http://rss.uol.com.br/feed/economia.xml

Added a safeguard.

Maybe we should assume RSS 2 in such cases?