### PR TITLE
Implement timeout option

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -12,6 +12,7 @@ const DEFAULT_HEADERS = {
   'Accept': 'application/rss+xml',
 }
 const DEFAULT_MAX_REDIRECTS = 5;
+const DEFAULT_TIMEOUT = 60000;
 
 class Parser {
   constructor(options={}) {
@@ -21,6 +22,7 @@ class Parser {
     options.customFields.item = options.customFields.item || [];
     options.customFields.feed = options.customFields.feed || [];
     if (!options.maxRedirects) options.maxRedirects = DEFAULT_MAX_REDIRECTS;
+    if (!options.timeout) options.timeout = DEFAULT_TIMEOUT;
     this.options = options;
     this.xmlParser = new xml2js.Parser(this.options.xml2js);
   }
@@ -97,7 +99,7 @@ class Parser {
           return this.parseString(xml).then(resolve, reject);
         });
       })
-      req.setTimeout(1000, function() {
+      req.setTimeout(this.options.timeout, function() {
         return reject(new Error("Request timed out " + feedUrl));
       });
       req.on('error', reject);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -97,6 +97,9 @@ class Parser {
           return this.parseString(xml).then(resolve, reject);
         });
       })
+      req.setTimeout(1000, function() {
+        return reject(new Error("Request timed out " + feedUrl));
+      });
       req.on('error', reject);
     });
     prom = utils.maybePromisify(callback, prom);


### PR DESCRIPTION
Implement a timeout option to prevent the parser from hanging on a bad feed.  Default timeout set to 60 seconds. 
Fixes #66 

The timeout can be tested via:
https://httpstat.us/400?sleep=15000

Adjust sleep time (ms) as needed to see the timeout trigger.