### PR TITLE
Fix RSSParser is not a constructor error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,18 @@
 import { Options } from 'xml2js';
 
-export interface Headers
+interface Headers
 {
     readonly Accept: string;
     readonly 'User-Agent': string;
 }
 
-export interface CustomFields
+interface CustomFields
 {
     readonly feed?: string[];
     readonly item?: string[] | string[][];
 }
 
-export interface ParserOptions
+interface ParserOptions
 {
     readonly xml2js?: Options;
     readonly headers?: Headers;
@@ -21,7 +21,7 @@ export interface ParserOptions
     readonly customFields?: CustomFields;
 }
 
-export interface Items {
+interface Items {
     [key: string]: any;
     link?: string;
     guid?: string;
@@ -34,7 +34,7 @@ export interface Items {
     contentSnippet?: string;
 }
 
-export interface Output {
+interface Output {
     [key: string]: any;
     link?: string;
     title?: string;
@@ -88,4 +88,4 @@ declare const Parser: {
         parseURL(feedUrl: string, callback?: (err: Error, feed: Output) => void, redirectCount?: number): Promise<Output>;
     };
 }
-export default Parser
+export = Parser


### PR DESCRIPTION
I've reverted this typings change: https://github.com/bobby-brennan/rss-parser/commit/e88c78e42ecdb51f2c8eb741276b1712d273603d as it breaks the current code usage. There's no other way to get it working. `export = Parser` is a valid syntax for CommonJS-exported modules (https://stackoverflow.com/a/51238234).

Unfortunately, I don't know how to have other types exported.

Resolves https://github.com/bobby-brennan/rss-parser/issues/90