### PR TITLE
fix(types): fix export of utility types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,27 +1,25 @@
 import { Options } from 'xml2js';
 
-interface Headers
-{
+declare namespace Parser {
+  export interface Headers {
     readonly Accept: string;
     readonly 'User-Agent': string;
-}
+  }
 
-interface CustomFields
-{
+  export interface CustomFields {
     readonly feed?: string[];
     readonly item?: string[] | string[][];
-}
+  }
 
-interface ParserOptions
-{
+  export interface ParserOptions {
     readonly xml2js?: Options;
     readonly headers?: Headers;
     readonly defaultRSS?: number;
     readonly maxRedirects?: number;
     readonly customFields?: CustomFields;
-}
+  }
 
-interface Items {
+  export interface Items {
     [key: string]: any;
     link?: string;
     guid?: string;
@@ -32,9 +30,9 @@ interface Items {
     isoDate?: string;
     categories?: string[];
     contentSnippet?: string;
-}
+  }
 
-interface Output {
+  export interface Output {
     [key: string]: any;
     link?: string;
     title?: string;
@@ -42,50 +40,58 @@ interface Output {
     feedUrl?: string;
     description?: string;
     itunes?: {
-        [key: string]: any;
-        image?: string;
-        owner?: {
-            name?: string;
-            email?: string;
-        };
-        author?: string;
-        summary?: string;
-        explicit?: string;
+      [key: string]: any;
+      image?: string;
+      owner?: {
+        name?: string;
+        email?: string;
+      };
+      author?: string;
+      summary?: string;
+      explicit?: string;
     };
+  }
 }
 
 /**
  * Class that handles all parsing or URL, or even XML, RSS feed to JSON.
  */
-declare const Parser: {
-    /**
-     * @param options - Parser options.
-     */
-    new(options?: ParserOptions): {
-       /**
-        * Parse XML content to JSON.
-        *
-        * @param xml - The xml to be parsed.
-        * @param callback - Traditional callback.
-        *
-        * @returns Promise that has the same Output as the callback.
-        */
-        parseString(xml: string, callback?: (err: Error, feed: Output) => void): Promise<Output>;
+declare class Parser {
+  /**
+   * @param options - Parser options.
+   */
+  constructor(options?: Parser.ParserOptions);
+  /**
+   * Parse XML content to JSON.
+   *
+   * @param xml - The xml to be parsed.
+   * @param callback - Traditional callback.
+   *
+   * @returns Promise that has the same Output as the callback.
+   */
+  parseString(
+    xml: string,
+    callback?: (err: Error, feed: Parser.Output) => void
+  ): Promise<Parser.Output>;
 
-        /**
-         * Parse URL content to JSON.
-         *
-         * @param feedUrl - The url that needs to be parsed to JSON.
-         * @param callback - Traditional callback.
-         * @param redirectCount - Max of redirects, default is set to five.
-         *
-         * @example
-         * await parseURL('https://www.reddit.com/.rss');
-         * parseURL('https://www.reddit.com/.rss', (err, feed) => { ... });
-         *
-         * @returns Promise that has the same Output as the callback.
-         */
-        parseURL(feedUrl: string, callback?: (err: Error, feed: Output) => void, redirectCount?: number): Promise<Output>;
-    };
+  /**
+   * Parse URL content to JSON.
+   *
+   * @param feedUrl - The url that needs to be parsed to JSON.
+   * @param callback - Traditional callback.
+   * @param redirectCount - Max of redirects, default is set to five.
+   *
+   * @example
+   * await parseURL('https://www.reddit.com/.rss');
+   * parseURL('https://www.reddit.com/.rss', (err, feed) => { ... });
+   *
+   * @returns Promise that has the same Output as the callback.
+   */
+  parseURL(
+    feedUrl: string,
+    callback?: (err: Error, feed: Parser.Output) => void,
+    redirectCount?: number
+  ): Promise<Parser.Output>;
 }
-export = Parser
+
+export = Parser;


### PR DESCRIPTION
Creates a namespace in order to properly support exporting utility types.

Also changed the const export into a class, since it is more clear that way imo.

Should resolve the discussion in #93 in a non-breaking way.

Sorry about the excessive formatting changes (removing semicolons and such) it was how my editor was set up and I'm to tired to fix it right now. If it's important, let me know and I'll change it when I've gotten some sleep.