### PR TITLE
Add support for relative redirects

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -85,7 +85,8 @@ class Parser {
           if (redirectCount === this.options.maxRedirects) {
             return reject(new Error("Too many redirects"));
           } else {
-            return this.parseURL(res.headers['location'], null, redirectCount + 1).then(resolve, reject);
+            const newLocation = url.resolve(feedUrl, res.headers['location']);
+            return this.parseURL(newLocation, null, redirectCount + 1).then(resolve, reject);
           }
         } else if (res.statusCode >= 300) {
           return reject(new Error("Status code " + res.statusCode))


### PR DESCRIPTION
We recently ran into the problem that a public feed moved to a new location.
The original request returns a 301 Moved Permanently now with a relative redirect. 
This works fine in the browser and with curl, but throws an exception with rss-parser.  

This pull request contains a test case and a possible fix.